### PR TITLE
On _save_session, set cookie to response and not to request.response

### DIFF
--- a/pyramid_pluggable_session/__init__.py
+++ b/pyramid_pluggable_session/__init__.py
@@ -314,7 +314,7 @@ def PluggableSessionFactory(
                     )
 
             self._plug.dumps(self, self.request, sess_val)
-            self._cookie.set_cookies(self.request.response, self._session_id)
+            self._cookie.set_cookies(response, self._session_id)
 
             return True
 


### PR DESCRIPTION
request.response and response can be different if a view return a new Response
